### PR TITLE
Update lab1.rst

### DIFF
--- a/docs/class6/lab1.rst
+++ b/docs/class6/lab1.rst
@@ -149,7 +149,7 @@ Now you are ready to test.
 
 1. Open a new browser window and open the URL for the virtual server
    that has the access policy applied:
-   `**https://server1.acme.com** <https://server1.acme.com>`
+   **https://server1.acme.com**
    You will be presented with a login window
    
    |image26|


### PR DESCRIPTION
hyperlink formatting issue: I removed hyperlink since this guide is typically viewed on a public machine and the lab env is private.